### PR TITLE
Service container should check if configuration exists when using isset

### DIFF
--- a/src/Service/Config/Container.php
+++ b/src/Service/Config/Container.php
@@ -93,7 +93,7 @@ trait Container
      */
     function has($name)
     {
-        return isset($this->container[$name]);
+        return isset($this->container[$name]) || isset($this->services[$name]);
     }
 
     /**


### PR DESCRIPTION
The coalescing operator [bug fix](https://bugs.php.net/bug.php?id=71359) for php 7 requires the service container to check the service configuration when a shared value does not exist. Otherwise it will not be retrieved, e.g Request\Config::path().